### PR TITLE
Airship 3195/fixes

### DIFF
--- a/bq_workers/actions-deployment_parser/requirements.txt
+++ b/bq_workers/actions-deployment_parser/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.2.5
 gunicorn==21.2.0
 google-cloud-bigquery==1.23.1
 git+https://github.com/GoogleCloudPlatform/fourkeys.git#egg=shared&subdirectory=shared

--- a/event_handler/requirements.txt
+++ b/event_handler/requirements.txt
@@ -1,4 +1,5 @@
-Flask==1.1.1
+Flask==2.2.5
+six==1.16.0
 gunicorn==19.9.0
 google-cloud-pubsub==1.1.0
 google-cloud-secret-manager==0.1.0


### PR DESCRIPTION
Although these images could build successfully they were failing when run. Updating `flask` and adding `six` (the gcp libs seem to depend on this) dependency seems to fix it locally.